### PR TITLE
Refactor privacy helper extraction and router integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ build/
 .venv/
 venv/
 env/
+.env
+.env.*
+!.env.example
 
 # IDE
 .vscode/
@@ -37,3 +40,4 @@ promote.sh
 #secrets
 .secrets/
 provision.config
+tri-tier-private-ai\tri-tier-private-ai.code-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ promote.sh
 #secrets
 .secrets/
 provision.config
-tri-tier-private-ai\tri-tier-private-ai.code-workspace
+*.code-workspace

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
         ipv4_address: 172.30.0.3
     volumes:
       - ./litellm_config.yaml:/app/config.yaml:ro
+      - ./utils:/app/utils:ro
       - ./router_hook.py:/app/router_hook.py:ro
       - ./entrypoint.py:/app/entrypoint.py:ro
       - ./local_memory.py:/app/local_memory.py:ro

--- a/router_hook.py
+++ b/router_hook.py
@@ -4,7 +4,7 @@ import re
 import urllib.request
 from litellm.integrations.custom_logger import CustomLogger
 
-from utils.privacy import _extract_user_message_text
+from utils.privacy import extract_user_message_text
 
 # Simple in-memory cache for classification results
 CLASSIFICATION_CACHE = {}
@@ -205,7 +205,7 @@ def _route(data):
         print(f"[PrivacyRouter] >>> DEBUG: Raw content type: {type(content)}", flush=True)
         
         # Extract the actual user message text (may include OpenClaw metadata wrapper)
-        user_text = _extract_user_message_text(content)
+        user_text = extract_user_message_text(content)
         print(f"[PrivacyRouter] >>> DEBUG: Extracted user text: '{user_text[:100]}...'", flush=True)
         
         if isinstance(content, str):

--- a/router_hook.py
+++ b/router_hook.py
@@ -4,6 +4,8 @@ import re
 import urllib.request
 from litellm.integrations.custom_logger import CustomLogger
 
+from utils.privacy import _extract_user_message_text
+
 # Simple in-memory cache for classification results
 CLASSIFICATION_CACHE = {}
 CACHE_MAX_SIZE = 100
@@ -185,66 +187,6 @@ def classify_complexity(message_content) -> str:
         print(f"[PrivacyRouter] Classification failed: {e} -> fallback to simple", flush=True)
         return "simple"  # Fallback to simple if classification fails
 
-def _extract_user_message_text(content) -> str:
-    """Extract the actual user message text from content that may include OpenClaw metadata wrapper.
-    
-    OpenClaw wraps user messages with metadata like:
-    Conversation info (untrusted metadata):
-    ```json
-    {...}
-    ```
-    
-    Sender (untrusted metadata):
-    ```json
-    {...}
-    ```
-    
-    The actual user message comes AFTER these metadata blocks.
-    """
-    if isinstance(content, str):
-        text = content
-    elif isinstance(content, list):
-        # Extract text from list parts
-        text_parts = []
-        for part in content:
-            if isinstance(part, dict) and part.get("type") in ("text", "input_text"):
-                text_parts.append(part.get("text", ""))
-            elif isinstance(part, str):
-                text_parts.append(part)
-        text = '\n'.join(text_parts)
-    else:
-        text = str(content)
-    
-    # Strategy: Find all metadata blocks and extract what comes after them
-    # Metadata blocks are marked by headers like "Conversation info (untrusted metadata):" or "Sender (untrusted metadata):"
-    # followed by ```json ... ```
-    
-    metadata_headers = [
-        'Conversation info (untrusted metadata):',
-        'Sender (untrusted metadata):',
-    ]
-    
-    # Find the position after all metadata blocks
-    remaining_text = text
-    for header in metadata_headers:
-        if header in remaining_text:
-            # Find the header and skip past the JSON block
-            idx = remaining_text.find(header)
-            if idx >= 0:
-                # Find the ```json marker after the header
-                json_start = remaining_text.find('```', idx)
-                if json_start >= 0:
-                    # Find the closing ```
-                    json_end = remaining_text.find('```', json_start + 3)
-                    if json_end >= 0:
-                        remaining_text = remaining_text[json_end + 3:].lstrip()
-    
-    # After removing all metadata blocks, remaining_text should be the user message
-    if remaining_text.strip():
-        return remaining_text.strip()
-    
-    # Fallback: return original text
-    return text
 
 
 def _route(data):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+import sys
+import types
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+def pytest_sessionstart(session):
+    if "litellm.integrations.custom_logger" in sys.modules:
+        return
+
+    litellm = types.ModuleType("litellm")
+    integrations = types.ModuleType("litellm.integrations")
+    custom_logger = types.ModuleType("litellm.integrations.custom_logger")
+
+    class CustomLogger:
+        pass
+
+    custom_logger.CustomLogger = CustomLogger
+    sys.modules["litellm"] = litellm
+    sys.modules["litellm.integrations"] = integrations
+    sys.modules["litellm.integrations.custom_logger"] = custom_logger

--- a/tests/test_privacy_utils.py
+++ b/tests/test_privacy_utils.py
@@ -14,7 +14,7 @@ Sender (untrusted metadata):
 
 [priv] actual message
 """
-    assert _extract_user_message_text(content) == "[priv] actual message"
+    assert extract_user_message_text(content) == "[priv] actual message"
 
 
 def test_extract_from_list_content():
@@ -29,14 +29,14 @@ def test_extract_from_list_content():
         },
         {"type": "text", "text": "real user text"},
     ]
-    assert _extract_user_message_text(content) == "real user text"
+    assert extract_user_message_text(content) == "real user text"
 
 
 def test_passthrough_when_no_metadata():
     content = "plain user text"
-    assert _extract_user_message_text(content) == "plain user text"
+    assert extract_user_message_text(content) == "plain user text"
 
 
 def test_fallback_on_malformed_block():
     content = "Conversation info (untrusted metadata):\n```json\n{bad\nplain fallback"
-    assert _extract_user_message_text(content) == content
+    assert extract_user_message_text(content) == content

--- a/tests/test_privacy_utils.py
+++ b/tests/test_privacy_utils.py
@@ -1,4 +1,4 @@
-from utils.privacy import _extract_user_message_text
+from utils.privacy import extract_user_message_text
 
 
 def test_extract_from_wrapped_string():

--- a/tests/test_privacy_utils.py
+++ b/tests/test_privacy_utils.py
@@ -1,0 +1,42 @@
+from utils.privacy import _extract_user_message_text
+
+
+def test_extract_from_wrapped_string():
+    content = """Conversation info (untrusted metadata):
+```json
+{"a": 1}
+```
+
+Sender (untrusted metadata):
+```json
+{"b": 2}
+```
+
+[priv] actual message
+"""
+    assert _extract_user_message_text(content) == "[priv] actual message"
+
+
+def test_extract_from_list_content():
+    content = [
+        {
+            "type": "text",
+            "text": "Conversation info (untrusted metadata):\n```json\n{}\n```",
+        },
+        {
+            "type": "input_text",
+            "text": "Sender (untrusted metadata):\n```json\n{}\n```",
+        },
+        {"type": "text", "text": "real user text"},
+    ]
+    assert _extract_user_message_text(content) == "real user text"
+
+
+def test_passthrough_when_no_metadata():
+    content = "plain user text"
+    assert _extract_user_message_text(content) == "plain user text"
+
+
+def test_fallback_on_malformed_block():
+    content = "Conversation info (untrusted metadata):\n```json\n{bad\nplain fallback"
+    assert _extract_user_message_text(content) == content

--- a/tests/test_router_routing.py
+++ b/tests/test_router_routing.py
@@ -1,0 +1,31 @@
+import router_hook
+
+def _req(content):
+    return {
+        "model": "cloud-simple",
+        "messages": [{"role": "user", "content": content}],
+        "metadata": {"chat_id": "test-chat"},
+        "tools": [{"type": "function", "function": {"name": "x"}}],
+        "max_completion_tokens": 128,
+    }
+
+def test_private_routes_local_and_strips_prefix(monkeypatch):
+    monkeypatch.setattr(router_hook, "LOCAL_MEMORY_ENABLED", False)
+    out = router_hook._route(_req("[priv] secret"))
+    assert out["model"] == "local-private"
+    assert out["messages"][0]["role"] == "system"
+    assert out["messages"][1]["role"] == "user"
+    assert out["messages"][1]["content"] == "secret"
+    assert "tools" not in out
+    assert "max_completion_tokens" not in out
+    assert out["max_tokens"] == 512
+
+def test_non_private_simple_route(monkeypatch):
+    monkeypatch.setattr(router_hook, "classify_complexity", lambda _: "simple")
+    out = router_hook._route(_req("hello"))
+    assert out["model"] == "cloud-simple"
+
+def test_non_private_complex_route(monkeypatch):
+    monkeypatch.setattr(router_hook, "classify_complexity", lambda _: "complex")
+    out = router_hook._route(_req("deep architecture question"))
+    assert out["model"] == "cloud-complex"

--- a/utils/privacy.py
+++ b/utils/privacy.py
@@ -1,0 +1,61 @@
+
+def _extract_user_message_text(content) -> str:
+    """Extract the actual user message text from content that may include OpenClaw metadata wrapper.
+    
+    OpenClaw wraps user messages with metadata like:
+    Conversation info (untrusted metadata):
+    ```json
+    {...}
+    ```
+    
+    Sender (untrusted metadata):
+    ```json
+    {...}
+    ```
+    
+    The actual user message comes AFTER these metadata blocks.
+    """
+    if isinstance(content, str):
+        text = content
+    elif isinstance(content, list):
+        # Extract text from list parts
+        text_parts = []
+        for part in content:
+            if isinstance(part, dict) and part.get("type") in ("text", "input_text"):
+                text_parts.append(part.get("text", ""))
+            elif isinstance(part, str):
+                text_parts.append(part)
+        text = '\n'.join(text_parts)
+    else:
+        text = str(content)
+    
+    # Strategy: Find all metadata blocks and extract what comes after them
+    # Metadata blocks are marked by headers like "Conversation info (untrusted metadata):" or "Sender (untrusted metadata):"
+    # followed by ```json ... ```
+    
+    metadata_headers = [
+        'Conversation info (untrusted metadata):',
+        'Sender (untrusted metadata):',
+    ]
+    
+    # Find the position after all metadata blocks
+    remaining_text = text
+    for header in metadata_headers:
+        if header in remaining_text:
+            # Find the header and skip past the JSON block
+            idx = remaining_text.find(header)
+            if idx >= 0:
+                # Find the ```json marker after the header
+                json_start = remaining_text.find('```', idx)
+                if json_start >= 0:
+                    # Find the closing ```
+                    json_end = remaining_text.find('```', json_start + 3)
+                    if json_end >= 0:
+                        remaining_text = remaining_text[json_end + 3:].lstrip()
+    
+    # After removing all metadata blocks, remaining_text should be the user message
+    if remaining_text.strip():
+        return remaining_text.strip()
+    
+    # Fallback: return original text
+    return text

--- a/utils/privacy.py
+++ b/utils/privacy.py
@@ -1,3 +1,4 @@
+from typing import Any
 
 def extract_user_message_text(content) -> str:
     """Extract the actual user message text from content that may include OpenClaw metadata wrapper.
@@ -33,6 +34,9 @@ def extract_user_message_text(content) -> str:
     # Metadata blocks are marked by headers like "Conversation info (untrusted metadata):" or "Sender (untrusted metadata):"
     # followed by ```json ... ```
     
+    # OpenClaw prepends untrusted metadata before the actual user text.
+    # Strip known wrapper blocks so privacy detection only sees the real message.
+
     metadata_headers = [
         'Conversation info (untrusted metadata):',
         'Sender (untrusted metadata):',
@@ -59,3 +63,7 @@ def extract_user_message_text(content) -> str:
     
     # Fallback: return original text
     return text
+
+def _extract_user_message_text(content: Any) -> str:
+    """Backward-compatible alias for older imports and tests."""
+    return extract_user_message_text(content)

--- a/utils/privacy.py
+++ b/utils/privacy.py
@@ -1,5 +1,5 @@
 
-def _extract_user_message_text(content) -> str:
+def extract_user_message_text(content) -> str:
     """Extract the actual user message text from content that may include OpenClaw metadata wrapper.
     
     OpenClaw wraps user messages with metadata like:


### PR DESCRIPTION
## Summary
Extracted the OpenClaw metadata-stripping helper into `utils/privacy.py` and updated the router to use the shared helper.

## What changed
- Moved user-message extraction logic into `utils/privacy.py`
- Kept a backward-compatible alias for older imports
- Updated `router_hook.py` to import the shared helper
- Added/updated tests for string, list, passthrough, and malformed metadata inputs
- Mounted `./utils` into the LiteLLM container in `docker-compose.yml` so the helper is available at runtime

## Validation
- `pytest` passed locally
- Private and non-private routing tests passed

## Notes
- `.env` is kept local and should not be committed
- This change does not alter routing behavior, only the helper location and import path

I havent fully tested with ollama and openclaw but the deterministic pytest indicates that the refactor is stable 